### PR TITLE
Avoids a warning in v5.24

### DIFF
--- a/lib/Template/Pure/ParseUtils.pm
+++ b/lib/Template/Pure/ParseUtils.pm
@@ -39,7 +39,7 @@ sub parse_data_template {
   my ($spec) = @_;
   $spec=~s/\r|\n//gs; # cleanup newlines.
 
-  my $opentag = qr/={/;
+  my $opentag = qr/=\{/;
   my $closetag = qr/}/;
   my $placeholder = qr{(
     (?:


### PR DESCRIPTION
e.g., Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/={ <-- HERE / at .../Template/Pure/ParseUtils.pm line 36, <DATA> line 2231.